### PR TITLE
Update consul timestamp to use supported python functions

### DIFF
--- a/consul/datadog_checks/consul/consul.py
+++ b/consul/datadog_checks/consul/consul.py
@@ -190,7 +190,7 @@ class ConsulCheck(AgentCheck):
                     instance_state.last_known_leader, leader))
 
                 self.event({
-                    "timestamp": int(datetime.now().strftime("%s")),
+                    "timestamp": int(datetime.now().timestamp()),
                     "event_type": "consul.new_leader",
                     "source_type_name": self.SOURCE_TYPE_NAME,
                     "msg_title": "New Consul Leader Elected in consul_datacenter:{0}".format(agent_dc),


### PR DESCRIPTION
Update consul implementation to use timestamp instead of strftime('%s') - this is unsupported particularly on Windows

### What does this PR do?

Updates the timestamp property with a supported timestamp value

### Motivation

Python 2.7 + Windows finds that strftime('%s') is invalid.

### Review checklist

- [ ] PR has a [meaningful title](https://github.com/DataDog/integrations-core/blob/master/CONTRIBUTING.md#pull-request-title) or PR has the `no-changelog` label attached
- [ ] Feature or bugfix has tests
- [ ] Git history is clean
- [ ] If PR impacts documentation, docs team has been notified or an issue has been opened on the [documentation repo](https://github.com/DataDog/documentation/issues/new)

### Additional Notes

Anything else we should know when reviewing?
